### PR TITLE
feat: add session-based tracking for anonymous web users

### DIFF
--- a/.src/lib/db/migrations/0002_heavy_pretty_boy.sql
+++ b/.src/lib/db/migrations/0002_heavy_pretty_boy.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "users" ADD COLUMN "session_id" varchar(36);--> statement-breakpoint
+CREATE UNIQUE INDEX "users_session_id_index" ON "users" USING btree ("session_id");

--- a/.src/lib/db/migrations/meta/0002_snapshot.json
+++ b/.src/lib/db/migrations/meta/0002_snapshot.json
@@ -1,0 +1,460 @@
+{
+  "id": "8322b503-c9cc-430a-90d0-25ac9d98a479",
+  "prevId": "63244be6-8275-4b3b-ae24-b7d91d038204",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.analyzed_url_results": {
+      "name": "analyzed_url_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(26)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "analyzed_url_revision_id": {
+          "name": "analyzed_url_revision_id",
+          "type": "varchar(26)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_analyzed_url_id": {
+          "name": "redirect_analyzed_url_id",
+          "type": "char(26)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_title": {
+          "name": "meta_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inserted_at": {
+          "name": "inserted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "analyzed_url_results_analyzed_url_revision_id_index": {
+          "name": "analyzed_url_results_analyzed_url_revision_id_index",
+          "columns": [
+            {
+              "expression": "analyzed_url_revision_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "analyzed_url_results_redirect_analyzed_url_id_index": {
+          "name": "analyzed_url_results_redirect_analyzed_url_id_index",
+          "columns": [
+            {
+              "expression": "redirect_analyzed_url_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "analyzed_url_results_analyzed_url_revision_id_analyzed_url_revisions_id_fk": {
+          "name": "analyzed_url_results_analyzed_url_revision_id_analyzed_url_revisions_id_fk",
+          "tableFrom": "analyzed_url_results",
+          "tableTo": "analyzed_url_revisions",
+          "columnsFrom": [
+            "analyzed_url_revision_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "restrict"
+        },
+        "analyzed_url_results_redirect_analyzed_url_id_analyzed_urls_id_fk": {
+          "name": "analyzed_url_results_redirect_analyzed_url_id_analyzed_urls_id_fk",
+          "tableFrom": "analyzed_url_results",
+          "tableTo": "analyzed_urls",
+          "columnsFrom": [
+            "redirect_analyzed_url_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.analyzed_url_revisions": {
+      "name": "analyzed_url_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(26)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "analyzed_url_id": {
+          "name": "analyzed_url_id",
+          "type": "char(26)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "char(26)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "char(26)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_channel_id": {
+          "name": "discord_channel_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'discord'"
+        },
+        "inserted_at": {
+          "name": "inserted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "analyzed_url_revisions_analyzed_url_id_index": {
+          "name": "analyzed_url_revisions_analyzed_url_id_index",
+          "columns": [
+            {
+              "expression": "analyzed_url_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "analyzed_url_revisions_user_id_index": {
+          "name": "analyzed_url_revisions_user_id_index",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "analyzed_url_revisions_guild_id_index": {
+          "name": "analyzed_url_revisions_guild_id_index",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "analyzed_url_revisions_analyzed_url_id_analyzed_urls_id_fk": {
+          "name": "analyzed_url_revisions_analyzed_url_id_analyzed_urls_id_fk",
+          "tableFrom": "analyzed_url_revisions",
+          "tableTo": "analyzed_urls",
+          "columnsFrom": [
+            "analyzed_url_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "restrict"
+        },
+        "analyzed_url_revisions_user_id_users_id_fk": {
+          "name": "analyzed_url_revisions_user_id_users_id_fk",
+          "tableFrom": "analyzed_url_revisions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "restrict"
+        },
+        "analyzed_url_revisions_guild_id_guilds_id_fk": {
+          "name": "analyzed_url_revisions_guild_id_guilds_id_fk",
+          "tableFrom": "analyzed_url_revisions",
+          "tableTo": "guilds",
+          "columnsFrom": [
+            "guild_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.analyzed_urls": {
+      "name": "analyzed_urls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(26)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "domain_hash": {
+          "name": "domain_hash",
+          "type": "char(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_hash": {
+          "name": "path_hash",
+          "type": "char(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "params_hash": {
+          "name": "params_hash",
+          "type": "char(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "analyzed_urls_domain_hash_index": {
+          "name": "analyzed_urls_domain_hash_index",
+          "columns": [
+            {
+              "expression": "domain_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "analyzed_urls_domain_hash_path_hash_params_hash_index": {
+          "name": "analyzed_urls_domain_hash_path_hash_params_hash_index",
+          "columns": [
+            {
+              "expression": "domain_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "params_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guilds": {
+      "name": "guilds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(26)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "discord_id": {
+          "name": "discord_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "guilds_discord_id_index": {
+          "name": "guilds_discord_id_index",
+          "columns": [
+            {
+              "expression": "discord_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "char(26)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "discord_id": {
+          "name": "discord_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ephemeral": {
+          "name": "ephemeral",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "users_discord_id_index": {
+          "name": "users_discord_id_index",
+          "columns": [
+            {
+              "expression": "discord_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_session_id_index": {
+          "name": "users_session_id_index",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/.src/lib/db/migrations/meta/_journal.json
+++ b/.src/lib/db/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1768528002800,
       "tag": "0001_legal_nehzno",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1768672139677,
+      "tag": "0002_heavy_pretty_boy",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safepeek-web",
-  "version": "0.4.2",
+  "version": "0.5.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/api/analyze/route.ts
+++ b/src/app/api/analyze/route.ts
@@ -10,6 +10,7 @@ type AnalyzedUrlPostData =
   | {
       url: string;
       source?: 'discord' | 'web';
+      sessionId?: string;
       metadata?: {
         discordUserId: string;
         discordChannelId: string;
@@ -72,6 +73,7 @@ export async function POST(request: Request) {
     const result = await createFromAnalyzedUrlData({
       analyzedUrlData: {
         userId: res.metadata?.discordUserId ? BigInt(res.metadata.discordUserId) : null,
+        sessionId: res.sessionId ?? null,
         channelId: res.metadata?.discordChannelId ? BigInt(res.metadata.discordChannelId) : null,
         guildId: res.metadata?.discordGuildId ? BigInt(res.metadata.discordGuildId) : null,
         source,

--- a/src/app/search/actions.ts
+++ b/src/app/search/actions.ts
@@ -13,7 +13,7 @@ type AnalysisResponse =
   | { success: true; data: AnalysisResult }
   | { success: false; error: string };
 
-export async function analyzeUrl(url: string): Promise<AnalysisResponse> {
+export async function analyzeUrl(url: string, sessionId?: string): Promise<AnalysisResponse> {
   try {
     const response = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000'}/api/analyze`, {
       method: 'POST',
@@ -23,7 +23,8 @@ export async function analyzeUrl(url: string): Promise<AnalysisResponse> {
       },
       body: JSON.stringify({
         url,
-        source: 'web'
+        source: 'web',
+        sessionId: sessionId || undefined
       })
     });
 

--- a/src/app/search/search-client.tsx
+++ b/src/app/search/search-client.tsx
@@ -2,11 +2,25 @@
 
 import type React from 'react';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Search, Link2, ArrowRight, ExternalLink, Shield, Loader2 } from 'lucide-react';
 import { analyzeUrl } from './actions';
+
+const SESSION_ID_KEY = 'safepeek_session_id';
+
+function getOrCreateSessionId(): string {
+  console.log('running getOrCreateSessionId');
+  if (typeof window === 'undefined') return '';
+
+  let sessionId = localStorage.getItem(SESSION_ID_KEY);
+  if (!sessionId) {
+    sessionId = crypto.randomUUID();
+    localStorage.setItem(SESSION_ID_KEY, sessionId);
+  }
+  return sessionId;
+}
 
 type AnalysisResult = {
   title: string;
@@ -22,6 +36,11 @@ export default function SearchClient() {
   const [isLoading, setIsLoading] = useState(false);
   const [result, setResult] = useState<AnalysisResult | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [sessionId, setSessionId] = useState<string>('');
+
+  useEffect(() => {
+    setSessionId(getOrCreateSessionId());
+  }, []);
 
   const handleAnalyze = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -36,7 +55,7 @@ export default function SearchClient() {
     setResult(null);
 
     try {
-      const response = await analyzeUrl(url.trim());
+      const response = await analyzeUrl(url.trim(), sessionId);
 
       if (!response.success) {
         setError(response.error || 'Failed to analyze URL');

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -29,10 +29,12 @@ export const users = pgTable(
       .$default(() => ulid())
       .primaryKey(),
     discordId: bigint('discord_id', { mode: 'bigint' }),
+    sessionId: varchar('session_id', { length: 36 }),
     ephemeral: boolean('ephemeral').default(true)
   },
   (columns) => ({
-    discordIdUnqIdx: uniqueIndex().on(columns.discordId)
+    discordIdUnqIdx: uniqueIndex().on(columns.discordId),
+    sessionIdUnqIdx: uniqueIndex().on(columns.sessionId)
   })
 );
 

--- a/src/lib/db/utils.ts
+++ b/src/lib/db/utils.ts
@@ -19,30 +19,57 @@ function takeFirstOrThrow<T>(results: T[]): T {
   return result;
 }
 
-async function upsertUser(discordId: bigint | null, tx: DrizzleClient) {
-  if (!discordId) {
-    // Create anonymous user without Discord ID
+type UpsertUserOptions = {
+  discordId?: bigint | null;
+  sessionId?: string | null;
+};
+
+async function upsertUser(options: UpsertUserOptions, tx: DrizzleClient) {
+  const { discordId, sessionId } = options;
+
+  // Discord users: upsert by discordId
+  if (discordId) {
+    const user = await tx.query.users.findFirst({
+      where: eq(users.discordId, discordId)
+    });
+
+    if (user) return user;
+
     return takeFirstOrThrow(
       await tx
         .insert(users)
         .values({
-          discordId: null
+          discordId
         })
         .returning()
     );
   }
 
-  const user = await tx.query.users.findFirst({
-    where: eq(users.discordId, discordId)
-  });
+  // Web users with session: upsert by sessionId
+  if (sessionId) {
+    const user = await tx.query.users.findFirst({
+      where: eq(users.sessionId, sessionId)
+    });
 
-  if (user) return user;
+    if (user) return user;
 
+    return takeFirstOrThrow(
+      await tx
+        .insert(users)
+        .values({
+          sessionId
+        })
+        .returning()
+    );
+  }
+
+  // Fallback: create anonymous user without any identifier
   return takeFirstOrThrow(
     await tx
       .insert(users)
       .values({
-        discordId
+        discordId: null,
+        sessionId: null
       })
       .returning()
   );
@@ -158,7 +185,13 @@ type CreateAnalyzedUrlDataProps = {
 
 export async function createFromAnalyzedUrlData(props: CreateAnalyzedUrlDataProps) {
   return db.transaction(async (tx) => {
-    const user = await upsertUser(props.analyzedUrlData.userId, tx);
+    const user = await upsertUser(
+      {
+        discordId: props.analyzedUrlData.userId,
+        sessionId: props.analyzedUrlData.sessionId
+      },
+      tx
+    );
     const guild = props.analyzedUrlData.guildId ? await upsertGuild(props.analyzedUrlData.guildId, tx) : { id: null };
 
     let previousRedirectAnalyzedUrlId: string | null = null;
@@ -209,6 +242,6 @@ type GetUserProfileProps = {
 
 export async function getUserProfile(props: GetUserProfileProps) {
   return db.transaction((tx) => {
-    return upsertUser(props.discordUserId, tx);
+    return upsertUser({ discordId: props.discordUserId }, tx);
   });
 }

--- a/src/types/url.ts
+++ b/src/types/url.ts
@@ -3,6 +3,7 @@ import { AnalyzedUrlRedirect } from '@safepeek/utils';
 export interface UrlAnalysisInputData {
   guildId: bigint | null;
   userId: bigint | null;
+  sessionId: string | null;
   channelId: bigint | null;
   source: 'discord' | 'web';
   urls: AnalyzedUrlRedirect[];


### PR DESCRIPTION
## Summary
- Add `sessionId` field to users table with unique index for tracking web users
- Update `upsertUser` to handle both Discord users (by discordId) and web users (by sessionId)
- Integrate session tracking in search client using localStorage with UUID generation
- Pass sessionId through the full request chain: client → server action → API → database

## Test plan
- [x] Verify session ID is generated and persisted in localStorage on first visit
- [x] Confirm same session ID is reused on subsequent page loads
- [x] Test that URL analyses are recorded with the session ID in the database
- [x] Verify Discord users continue to work without session tracking

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)