### PR TITLE
fix: resolve 403 errors in URL validation

### DIFF
--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -10,12 +10,21 @@ const fetcher = (url: string, opts?: FetcherOpts) => {
   return fetch(url, {
     redirect: opts?.follow ? 'follow' : 'manual',
     headers: {
-      'User-Agent': 'SafePeekWeb (https://github.com/safepeek/web, 1.0.0)',
-      Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
-      'Accept-Language': 'en-US,en;q=0.5',
-      'Accept-Encoding': 'gzip, deflate',
-      'Content-Type': 'text/html',
-      Referer: 'https://google.com'
+      'User-Agent':
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+      Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8',
+      'Accept-Language': 'en-US,en;q=0.9',
+      'Accept-Encoding': 'gzip, deflate, br',
+      'Cache-Control': 'no-cache',
+      Pragma: 'no-cache',
+      'Sec-Ch-Ua': '"Google Chrome";v="131", "Chromium";v="131", "Not_A Brand";v="24"',
+      'Sec-Ch-Ua-Mobile': '?0',
+      'Sec-Ch-Ua-Platform': '"Windows"',
+      'Sec-Fetch-Dest': 'document',
+      'Sec-Fetch-Mode': 'navigate',
+      'Sec-Fetch-Site': 'none',
+      'Sec-Fetch-User': '?1',
+      'Upgrade-Insecure-Requests': '1'
     },
     signal: opts?.signal
   });

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -33,12 +33,9 @@ export const validateUrl = async (url: string): Promise<boolean> => {
 
     clearTimeout(timeoutId);
 
-    if (!response.ok) {
-      console.error(`URL validation failed with status: ${response.status}`);
-      return false;
-    }
-
-    return response.ok;
+    // Accept any response that isn't a server error (5xx)
+    // 4xx responses (like 403) still provide valuable data (destination URL, redirects)
+    return response.status < 500;
   } catch (error: any) {
     console.error(`Error validating URL: ${url}`, error.message);
     console.error(error.stack);


### PR DESCRIPTION
## Summary
- Accept 4xx responses (like 403) in URL validation since they still provide valuable data (destination URL, redirects)
- Replace bot-identifiable User-Agent with Chrome 131 browser fingerprint
- Add Sec-Ch-Ua and Sec-Fetch headers that modern sites expect from real browsers

Closes #4

## Test plan
- [x] Tested against sites that were previously returning 403
- [x] Verify metadata (title, description) is retrieved correctly
- [x] Confirm redirects are still tracked properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)